### PR TITLE
Fix several memory leaks

### DIFF
--- a/src/line_protocol_parser.c
+++ b/src/line_protocol_parser.c
@@ -252,6 +252,7 @@ parse_value(struct LP_Item* item)
     endptr = NULL;
     candidate_d = strtod(item->value.s, &endptr);
     if (*endptr == '\0') {
+        LP_FREE(item->value.s);
         item->value.f = candidate_d;
         item->type = LP_FLOAT;
         LP_DEBUG_PRINT("Type is double: %f\n", candidate_d);
@@ -262,6 +263,7 @@ parse_value(struct LP_Item* item)
     endptr = NULL;
     candidate_i = strtoll(item->value.s, &endptr, 10);
     if (*endptr == 'i' && *(endptr + 1) == '\0') {
+        LP_FREE(item->value.s);
         item->value.i = candidate_i;
         item->type = LP_INTEGER;
         LP_DEBUG_PRINT("Type is integer: %lld\n", candidate_i);
@@ -283,11 +285,13 @@ parse_value(struct LP_Item* item)
 
     // Try parse boolan
     if (length == 1 && tolower(*(item->value.s)) == 't' ) {
+        LP_FREE(item->value.s);
         item->value.b = 1;
         item->type = LP_BOOLEAN;
         LP_DEBUG_PRINT("Type is boolean: %d\n", item->value.b);
         return 1;
     } else if (length == 1 && tolower(*(item->value.s)) == 'f' ) {
+        LP_FREE(item->value.s);
         item->value.b = 0;
         item->type = LP_BOOLEAN;
         LP_DEBUG_PRINT("Type is boolean: %d\n", item->value.b);
@@ -298,11 +302,13 @@ parse_value(struct LP_Item* item)
             boolstr[i] = tolower(item->value.s[i]);
         }
         if ((strcmp(boolstr, "true") == 0)) {
+            LP_FREE(item->value.s);
             item->value.b = 1;
             item->type = LP_BOOLEAN;
             LP_DEBUG_PRINT("Type is boolean: %d\n", item->value.b);
             return 1;
         } else if ((strcmp(boolstr, "false") == 0)) {
+            LP_FREE(item->value.s);
             item->value.b = 0;
             item->type = LP_BOOLEAN;
             LP_DEBUG_PRINT("Type is boolean: %d\n", item->value.b);

--- a/src/module.c
+++ b/src/module.c
@@ -108,6 +108,7 @@ try:
         if ((PyDict_SetItemString(tags, tmp->key, tag_value)) == -1) {
             goto except;
         }
+        Py_DECREF(tag_value);
         tmp = tmp->next_item;
     }
     if ((fields = PyDict_New()) == NULL) {
@@ -136,6 +137,7 @@ try:
             if ((PyDict_SetItemString(fields, tmp->key, field_value)) == -1) {
                 goto except;
             }
+            Py_DECREF(field_value);
             tmp = tmp->next_item;
         }
     }
@@ -151,17 +153,17 @@ try:
     assert(!PyErr_Occurred());
     goto finally;
 except:
-    Py_XDECREF(measurement);
-    Py_XDECREF(tags);
-    Py_XDECREF(fields);
-    Py_XDECREF(time);
     Py_XDECREF(tag_value);
     Py_XDECREF(field_value);
     output = NULL;
 finally:
+    Py_XDECREF(measurement);
+    Py_XDECREF(tags);
+    Py_XDECREF(fields);
+    Py_XDECREF(time);
     Py_XDECREF(input);
     if (point != NULL){
-        PyMem_Free(point);
+        LP_free_point(point);
     }
     return output;
 }


### PR DESCRIPTION
Hey Daniel and thanks for this library!

I have encountered the same issue as described by @chinese-soup in #2. This PR should fix it.

A simple test case is as follows
```
import line_protocol_parser
import gc

while True:
    line = line_protocol_parser.parse_line('my_test,t=4,ahoj=3 value=4.5,test=2.5 325')
    gc.collect()
```
This would quickly eat up several GB of RAM. With changes in this PR, the memory usage stays below 4 MB.
