### PR TITLE
Make timestamp optional

### DIFF
--- a/src/line_protocol_parser.c
+++ b/src/line_protocol_parser.c
@@ -209,6 +209,10 @@ search_comma_space(const char *line, size_t start, size_t end, enum _LP_Part par
                 return i;
             }
         }
+        else if (i+1 == end && part == LP_FIELD_VALUE) {
+            LP_DEBUG_PRINT("reached end of line and we're parsing a field value %c\n", line[i]);
+            return i+1;
+        }
     }
     return 0; // Error
 }
@@ -426,7 +430,7 @@ LP_parse_line(const char *line, int *status)
         LP_DEBUG_PRINT("New field key: %s\n", item->key);
         start = index + 1;
         // FIELD VALUE
-        if ((index = search_comma_space(line, start, end, LP_FIELD_VALUE)) == 0){
+        if ((index = search_comma_space(line, start, end, LP_FIELD_VALUE)) == 0) {
             // Failed to find end of field value
             *status = LP_FIELD_VALUE_ERROR;
             goto error;
@@ -451,13 +455,21 @@ LP_parse_line(const char *line, int *status)
     if (item != NULL) {
         point->fields = item;
     }
+
     // Parse the nanosecond timestamp
-    point->time = strtoull(line + start, &endptr_time, 10);
-    LP_DEBUG_PRINT("Time: %llu\n", point->time);
-    if (*endptr_time != '\0' && *endptr_time != '\n' && *endptr_time != '\r') {
-        // Failed to parse whole nanosecond timestamp
-        *status = LP_TIME_ERROR;
-        goto error;
+    if(start >= end)
+    {
+        point->time = 0;
+    }
+    else
+    {
+        point->time = strtoull(line + start, &endptr_time, 10);
+        LP_DEBUG_PRINT("Time: %llu\n", point->time);
+        if (*endptr_time != '\0' && *endptr_time != '\n' && *endptr_time != '\r') {
+            // Failed to parse whole nanosecond timestamp
+            *status = LP_TIME_ERROR;
+            goto error;
+        }
     }
     goto done;
 error:

--- a/src/line_protocol_parser.c
+++ b/src/line_protocol_parser.c
@@ -457,12 +457,9 @@ LP_parse_line(const char *line, int *status)
     }
 
     // Parse the nanosecond timestamp
-    if(start >= end)
-    {
+    if(start >= end) {
         point->time = 0;
-    }
-    else
-    {
+    } else {
         point->time = strtoull(line + start, &endptr_time, 10);
         LP_DEBUG_PRINT("Time: %llu\n", point->time);
         if (*endptr_time != '\0' && *endptr_time != '\n' && *endptr_time != '\r') {

--- a/tests/test_parse_line.py
+++ b/tests/test_parse_line.py
@@ -57,8 +57,16 @@ class TestPoint(unittest.TestCase):
         p = parse_line('foobar,tag1=1 f1=3.14 0')
         self.assertAlmostEqual(p['fields']['f1'], 3.14)
 
+    def test_from_line_field_values_float_without_timestamp(self):
+        p = parse_line('foobar,tag1=1 f1=3.14')
+        self.assertAlmostEqual(p['fields']['f1'], 3.14)
+
     def test_from_line_field_values_integer(self):
         p = parse_line('foobar,tag1=1 f1=123i 0')
+        self.assertAlmostEqual(p['fields']['f1'], 123)
+
+    def test_from_line_field_values_integer_without_timestamp(self):
+        p = parse_line('foobar,tag1=1 f1=123i')
         self.assertAlmostEqual(p['fields']['f1'], 123)
 
     def test_from_line_field_values_big_integer(self):
@@ -145,7 +153,7 @@ class TestPoint(unittest.TestCase):
 
     def test_field_value_error(self):
         with self.assertRaisesRegex(LineFormatError, 'value of field'):
-            parse_line('measurement,tag=value field=1.23')
+            parse_line('measurement,tag=value field=')
 
     def test_field_value_type_error(self):
         with self.assertRaisesRegex(LineFormatError, 'type of field'):


### PR DESCRIPTION
This fixes #4 in a rather hacky-way:

If we're parsing a field value via **search_comma_space** and the index hits the end of the line (the line doesn't have a null terminator?) we return the last index.

Though this only works when there's only one field present, so we have to catch that at the end of **LP_parse_line** and set the timestamp to 0 if the _start_ index for the next "item" (in this case timestamp) is bigger or equal than the length of the line (_end_).

I've also added two tests for a measurement with an integer field and a measurement with float field without timestamps and changed the test for _field value error_ as the original one was a valid InfluxDB line and was incorrectly failing after this fix.

Review and/or different implementation very welcome. :)
