### PR TITLE
Added parsing of uint numbers (InfluxDB 2.0)

### DIFF
--- a/include/line_protocol_parser.h
+++ b/include/line_protocol_parser.h
@@ -16,7 +16,7 @@
 
 /* Indicates which type a field has */
 enum LP_ValueType {
-    LP_FLOAT, LP_INTEGER, LP_BOOLEAN, LP_STRING
+    LP_FLOAT, LP_INTEGER, LP_UINTEGER, LP_BOOLEAN, LP_STRING
 };
 
 /* Represents the value of a tag or field.

--- a/src/line_protocol_parser.c
+++ b/src/line_protocol_parser.c
@@ -246,6 +246,7 @@ parse_value(struct LP_Item* item)
     size_t length = 0;
     double candidate_d = 0;
     signed long long candidate_i = 0;
+    unsigned long long candidate_u = 0ULL;
     char boolstr[6];
     char *endptr = NULL;
 
@@ -271,6 +272,21 @@ parse_value(struct LP_Item* item)
         item->value.i = candidate_i;
         item->type = LP_INTEGER;
         LP_DEBUG_PRINT("Type is integer: %lld\n", candidate_i);
+        return 1;
+    }
+
+    // Try parse unsigned integer
+    endptr = NULL;
+    errno = 0; // we need to reset, otherwise errno MIGHT be the value of the strtoll above
+    candidate_u = strtoull(item->value.s, &endptr, 10);
+    if (*endptr == 'u' && *(endptr + 1) == '\0') {
+        LP_FREE(item->value.s);
+        if (candidate_u == ULLONG_MAX && errno == ERANGE)
+            return 0;
+
+        item->value.i = candidate_u;
+        item->type = LP_UINTEGER;
+        LP_DEBUG_PRINT("Type is uinteger: %llu\n", candidate_u);
         return 1;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -124,6 +124,9 @@ try:
                 case LP_INTEGER:
                     field_value = PyLong_FromLongLong(tmp->value.i);
                     break;
+                case LP_UINTEGER:
+                    field_value = PyLong_FromUnsignedLongLong(tmp->value.i);
+                    break;
                 case LP_BOOLEAN:
                     field_value = PyBool_FromLong(tmp->value.b);
                     break;

--- a/tests/test_parse_line.py
+++ b/tests/test_parse_line.py
@@ -65,6 +65,10 @@ class TestPoint(unittest.TestCase):
         p = parse_line('foobar,tag1=1 f1=123i 0')
         self.assertAlmostEqual(p['fields']['f1'], 123)
 
+    def test_from_line_field_values_uinteger(self):
+        p = parse_line('foobar,tag1=1 f1=123u 0')
+        self.assertAlmostEqual(p['fields']['f1'], 123)
+
     def test_from_line_field_values_integer_without_timestamp(self):
         p = parse_line('foobar,tag1=1 f1=123i')
         self.assertAlmostEqual(p['fields']['f1'], 123)


### PR DESCRIPTION
Hello.

This fixes #8 

I've opted for returning **an error** for values higher than `18446744073709551615u` (64bit system), but negative values such as `-1` don't throw an error since `strtoull` doesn't treat it as an invalid value (errno stays 0), see:

- https://github.com/gcc-mirror/gcc/blob/master/libiberty/strtoull.c
- https://stackoverflow.com/questions/55052640/surprising-behavior-of-strtoull-1-null-0-and-other-negative-values/55052768

It only sets `errno` to `ERANGE` for values above 18446744073709551615, not for values below 0:
```
If the value read is out of the range of representable values by an unsigned long long int,
the function returns ULLONG_MAX (defined in <climits>), and errno is set to ERANGE.
```

See resulting behaviour:
```
Parsing 18446744073709551615u
A =  {'measurement': 'measurement', 'tags': {'tag': '1'}, 'fields': {'field3': 18446744073709551615}, 'time': 0}

Parsing 18446744073709551616u
B failed Failed to parse type of field value.

Parsing -1u
C= {'measurement': 'measurement', 'tags': {'tag': '1'}, 'fields': {'field3': 18446744073709551615}, 'time': 0}

Parsing 123456789u
D= {'measurement': 'measurement', 'tags': {'tag': '1'}, 'fields': {'field3': 123456789}, 'time': 0}
```


